### PR TITLE
Add required flag to outfn cli

### DIFF
--- a/scripts/skysat_overlap.py
+++ b/scripts/skysat_overlap.py
@@ -18,10 +18,10 @@ import pandas as pd
 def getparser():
     parser = argparse.ArgumentParser(description='Script to make overlapping pairs based on user defined minimum overlap percentage')
     parser.add_argument('-img_folder', help='Folder containing images with RPC information', required=True)
-    parser.add_argument('-percentage', '--percentage', help='percentage_overlap between 0 to 1',type=float, required=True)
-    parser.add_argument('-outfn','--out_fn',help='Text file containing the overlapping pairs')
+    parser.add_argument('-percentage', '--percentage', help='percentage_overlap between 0 to 1', type=float, required=True)
+    parser.add_argument('-outfn','--out_fn',help='Text file containing the overlapping pairs', type=str, required=True)
     parser.add_argument('-cross_track',action='store_true',help='Also make cross-track pairs')
-    parser.add_argument('-aoi_bbox',help='Return interesecting footprint within this aoi only',default=None)
+    parser.add_argument('-aoi_bbox',help='Return interesecting footprint within this aoi only', default=None)
     return parser
 
 # Global var


### PR DESCRIPTION
Running `skysat_overlap.py` without specifying `-outfn` will crash with an error about not being able to open files of type NoneType. 

The script expects it to be there, but isn't listed as required, so this PR makes it a requirement. 

Also, made a few formatting changes for consistency. 