### PR TITLE
Change to CRS for calculating centroid

### DIFF
--- a/skysat_stereo/skysat_stereo_workflow.py
+++ b/skysat_stereo/skysat_stereo_workflow.py
@@ -40,7 +40,7 @@ def prepare_stereopair_list(img_folder,perc_overlap,out_fn,aoi_bbox=None,cross_t
     print (f'Bounding box lon_lat is:{bbox}')
     bound_poly = Polygon([[bbox[0],bbox[3]],[bbox[2],bbox[3]],[bbox[2],bbox[1]],[bbox[0],bbox[1]]])
     bound_shp = gpd.GeoDataFrame(index=[0],geometry=[bound_poly],crs=geo_crs)
-    bound_centroid = bound_shp.centroid
+    bound_centroid = bound_shp.to_crs('+proj=cea').centroid.to_crs(bound_shp.crs)
     cx = bound_centroid.x.values[0]
     cy = bound_centroid.y.values[0]
     pad = np.ptp([bbox[3],bbox[1]])/6.0


### PR DESCRIPTION
When calculating overlap geopandas raises a warning: 
```
skysat_stereo_workflow.py:43: UserWarning: Geometry is in a geographic CRS. Results from 'centroid' are likely incorrect. Use 'GeoSeries.to_crs()' to re-project geometries to a projected CRS before this operation.
```

I implemented the solution from [here](https://gis.stackexchange.com/questions/372564/userwarning-when-trying-to-get-centroid-from-a-polygon-geopandas), which changes to an equidistant projection before centroid calculation. 

In practice, we are not dealing with huge distances here, so probably overkill, but gets geopandas to shut up and technically the correct thing to do. 